### PR TITLE
Remove uninterpreted variable from npm scripts example

### DIFF
--- a/docs/guide/integration/build-tools.md
+++ b/docs/guide/integration/build-tools.md
@@ -83,13 +83,13 @@ Because the locally-installed Fractal module also includes the [CLI tool](../cli
 
 An example `package.json` file may therefore look like this:
 
-```
+```json
 {
   "name": "foocorp-component-library",
   "version": "1.0.0",
   "description": "FooCorp Component Library.",
   "devDependencies": {
-    "@frctl/fractal": "^{{ _config.project.version }}",
+    "@frctl/fractal": "…",
   },
   "scripts": {
     "start": "fractal start --sync",


### PR DESCRIPTION
I think this variable came from the previous docs which was then interpreted. I don't think we have any more information about the current fractal release in here so I suggest to just drop it instead.

I took the opportunity to highlight the code block as JSON.