### PR TITLE
Fix default component property code

### DIFF
--- a/docs/guide/components/configuration-reference.md
+++ b/docs/guide/components/configuration-reference.md
@@ -178,7 +178,7 @@ context:
 The name of the variant that should be used as the default variant. Defaults to `default`.
 
 ```yaml
-context: primary
+default: primary
 ```
 
 ### display


### PR DESCRIPTION
The example code in the default configuration property must be:

```yaml
default: primary
```
Instead of

```yaml
context: primary
```

Cheers. 😊 