### PR TITLE
Use request-promise-native instead of request-promise in example

### DIFF
--- a/docs/guide/core-concepts/context-data.md
+++ b/docs/guide/core-concepts/context-data.md
@@ -164,7 +164,7 @@ In the following example, we are going to make a request to our fictional member
 // member-list.config.js
 "use strict";
 
-const request = require("request-promise-native"); // require the request-promise module
+const request = require("request-promise-native"); // require the request-promise-native module
 
 // make the request to the API, returns a Promise
 const response = request({

--- a/docs/guide/core-concepts/context-data.md
+++ b/docs/guide/core-concepts/context-data.md
@@ -2,7 +2,7 @@
 title: Context Data
 ---
 
-# Context Data 
+# Context Data
 
 Context data is data that is made available to your [view templates](./configuration-files.html) when they are rendered.
 
@@ -71,6 +71,7 @@ context:
     - three
     - four
 ```
+
 It is then possible to access the `list-items` component's context data in another component as follows:
 
 ```yaml
@@ -88,6 +89,7 @@ context:
       - three
       - four
 ```
+
 You can also choose to access only part of another component's context data by using a dot-notation string after the main identifier handle:
 
 ```yaml
@@ -108,85 +110,85 @@ context:
 The reference syntax only applies to items of **the same type** - a component cannot access a documentation page's context data (or vice versa).
 :::
 
- ## Dynamic data
+## Dynamic data
 
- Fractal provides the option [to use CommonJS-style modules](./configuration-files.html#javascript-module-format) to define configuration data for components and documentation pages. Whilst slightly more complex than using JSON or YAML as a data format, it has the advantage of letting you be able to use the full power of JavaScript to generate context data for your components.
+Fractal provides the option [to use CommonJS-style modules](./configuration-files.html#javascript-module-format) to define configuration data for components and documentation pages. Whilst slightly more complex than using JSON or YAML as a data format, it has the advantage of letting you be able to use the full power of JavaScript to generate context data for your components.
 
- This can be handy if you want to provide data to your components from an API, or to use a library such as [Faker](https://github.com/marak/Faker.js) to generate placeholder data for your components.
+This can be handy if you want to provide data to your components from an API, or to use a library such as [Faker](https://github.com/marak/Faker.js) to generate placeholder data for your components.
 
- You can use any NodeJS functionality or NPM modules you like in your configuration data files, so the possibilities for generating dynamic data are effectively endless!
+You can use any NodeJS functionality or NPM modules you like in your configuration data files, so the possibilities for generating dynamic data are effectively endless!
 
- ### Generating dynamic data with Faker
+### Generating dynamic data with Faker
 
- To save us hard-coding lots of context data into our data file, we can use the excellent [faker.js](https://github.com/marak/Faker.js) library to generate a list of members for us.
+To save us hard-coding lots of context data into our data file, we can use the excellent [faker.js](https://github.com/marak/Faker.js) library to generate a list of members for us.
 
- First you'll need to make sure you have installed Faker in your component library project - `npm install faker --save`.
+First you'll need to make sure you have installed Faker in your component library project - `npm install faker --save`.
 
- And now let's look at an example `member-list.config.js` file and see how we can use Faker to dynamically generate a list of members for us.
+And now let's look at an example `member-list.config.js` file and see how we can use Faker to dynamically generate a list of members for us.
 
- ```js
- // member-list.config.js
- 'use strict';
+```js
+// member-list.config.js
+"use strict";
 
- const faker = require('faker'); // require the faker module
- const memberCount = 10; // how many members we should generate data for
- const memberData = [];
+const faker = require("faker"); // require the faker module
+const memberCount = 10; // how many members we should generate data for
+const memberData = [];
 
- for (var i = 0; i < memberCount; i++) {
-     memberData.push({
-         name: faker.name.findName(), // generate a random name
-         email: faker.internet.email()  // generate a random email address
-     });
- }
+for (var i = 0; i < memberCount; i++) {
+  memberData.push({
+    name: faker.name.findName(), // generate a random name
+    email: faker.internet.email() // generate a random email address
+  });
+}
 
- module.exports = {
- 	context: {
- 		members: memberData // use our generated list of members as context data for our template.
- 	}
- };
- ```
+module.exports = {
+  context: {
+    members: memberData // use our generated list of members as context data for our template.
+  }
+};
+```
 
- When our component is now rendered with this data, we will get a list of ten members, all with realistic names and email addresses. And if we want to generate 100 list items instead, all we have to do is update the value of the `memberCount` constant to 100.
+When our component is now rendered with this data, we will get a list of ten members, all with realistic names and email addresses. And if we want to generate 100 list items instead, all we have to do is update the value of the `memberCount` constant to 100.
 
- Obviously this is a simple example, but the principle can often be useful when you want to preview components with large amounts of data in them.
+Obviously this is a simple example, but the principle can often be useful when you want to preview components with large amounts of data in them.
 
- ### Using data from an API
+### Using data from an API
 
- If you already have an API for your site or application, and you want to preview your components using 'real' data (or indeed if you want to use content from any other APIs) then you can handle that in your component configuration files too.
+If you already have an API for your site or application, and you want to preview your components using 'real' data (or indeed if you want to use content from any other APIs) then you can handle that in your component configuration files too.
 
- The key to this is that if any values in the context data are [Promises](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise), Fractal will first wait for those promises to be resolved before rendering the template using the context data. So we can use a Promise-based request module (such as [request-promise](https://github.com/request/request-promise)) to make API requests and then just pass the returned promise into our context data object.
+The key to this is that if any values in the context data are [Promises](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise), Fractal will first wait for those promises to be resolved before rendering the template using the context data. So we can use a Promise-based request module (such as [request-promise-native](https://github.com/request/request-promise-native)) to make API requests and then just pass the returned promise into our context data object.
 
- In the following example, we are going to make a request to our fictional members API endpoint, which returns a JSON-encoded list of members.
+In the following example, we are going to make a request to our fictional members API endpoint, which returns a JSON-encoded list of members.
 
- ```js
- // member-list.config.js
- 'use strict';
+```js
+// member-list.config.js
+"use strict";
 
- const request = require('request-promise'); // require the request-promise module
+const request = require("request-promise-native"); // require the request-promise module
 
- // make the request to the API, returns a Promise
- const response = request({
-     uri: 'http://www.mysite-api.com/members',
-     json: true
- });
+// make the request to the API, returns a Promise
+const response = request({
+  uri: "http://www.mysite-api.com/members",
+  json: true
+});
 
- // do some post-processing on the response to wrangle it into the correct format
- response.then(function (membersApiData) {
-     const memberData = [];
-     for (let member of membersApiData) {
-         memberData.push({
-             name: `${member.firstName} ${member.lastName}`,
-             email: member.emailAddress
-         });
-     }
-     return memberData;
- });
+// do some post-processing on the response to wrangle it into the correct format
+response.then(function(membersApiData) {
+  const memberData = [];
+  for (let member of membersApiData) {
+    memberData.push({
+      name: `${member.firstName} ${member.lastName}`,
+      email: member.emailAddress
+    });
+  }
+  return memberData;
+});
 
- module.exports = {
- 	context: {
- 		members: response // use the response as context data for our template.
- 	}
- };
- ```
+module.exports = {
+  context: {
+    members: response // use the response as context data for our template.
+  }
+};
+```
 
- Now when the component is rendered, it will first make an API request to the endpoint and wait for the Promise (and its associated `then()` step) to be resolved before using the output to pass as context data to the template.
+Now when the component is rendered, it will first make an API request to the endpoint and wait for the Promise (and its associated `then()` step) to be resolved before using the output to pass as context data to the template.


### PR DESCRIPTION
A few people on the Slack channel have reported issues when using `request-promise` to make API requests to load context data. After investigation, using `request-promise-native` fixes the issue and so this pull request updates the docs to use that module instead.

I'm unclear why this is happening with the original `request-promise` lib - I suspect it's something to do with Bluebird and probably warrants further investigation. But until that time this should stop others running into the same issue.