### PR TITLE
Add missing `/` on a few links

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -90,7 +90,7 @@ Components can be very simple, consisting of just a single view template file, o
 1. Create a view file within there called `<component-name>.hbs` (The `.hbs` extension is the extension for Handlebars templates, the view template engine that Fractal uses by default);
 1. Add a configuration file that contains some context data that we want to use to render the view template with. -->
 
-Obviously this isn't a very exciting component at this point, but there is [plenty more you can do](./components) once you've got to grips with the basics.
+Obviously this isn't a very exciting component at this point, but there is [plenty more you can do](./components/) once you've got to grips with the basics.
 
 ### 4. Add a documentation index page
 
@@ -125,4 +125,4 @@ Once it has booted up you should see something like this in your terminal window
 
 If so, visit the 'Local URL' (It should be something like [http://localhost:3000](http://localhost:3000)) and have a look at your component library's web UI.
 
-The [web UI docs](./web) has full details on the options available when starting up development servers, as well as information on how to run static HTML exports of your component library UI and more.
+The [web UI docs](./web/) has full details on the options available when starting up development servers, as well as information on how to run static HTML exports of your component library UI and more.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -28,4 +28,4 @@ To install the Fractal CLI tool, run the following command from your terminal:
 npm i -g @frctl/fractal
 ```
 
-You can then run tasks using the `fractal <task-name>` format from your terminal - see the [CLI tool documentation](./cli) for full details.
+You can then run tasks using the `fractal <task-name>` format from your terminal - see the [CLI tool documentation](./cli/) for full details.

--- a/docs/guide/project-settings.md
+++ b/docs/guide/project-settings.md
@@ -12,7 +12,7 @@ Fractal comes with a few sensible defaults, but before you can get your project 
 
 By convention, project configuration and setup information should be kept in a file called `fractal.js` that lives in the **root of your project directory**.
 
-If you are using the Fractal [CLI tool](./cli) this file will need to exist (and be set up correctly) before you can run commands on your project.
+If you are using the Fractal [CLI tool](./cli/) this file will need to exist (and be set up correctly) before you can run commands on your project.
 
 ::: tip A note on paths
 When setting paths to directories in your Fractal configuration, it's possible to specify them relative to the root of your project directory - i.e. `src/components`. However it's recommended that you instead make use of Node's [`\__dirname`](https://nodejs.org/docs/latest/api/globals.html#globals_dirname) global to generate full absolute paths that look like:
@@ -52,7 +52,7 @@ Apart from the `project.title` value, Fractal will not use any of these other va
 
 Component configuration is done using the [`fractal.components.set()`](../api/endpoints/fractal-components.html#set-path-value) method.
 
-To specify the directory that your [components](./components) will be created in, you can use the `path` setting:
+To specify the directory that your [components](./components/) will be created in, you can use the `path` setting:
 
 ```js
 fractal.components.set('path', __dirname + '/src/components');
@@ -65,7 +65,7 @@ The [components configuration reference](./components/configuration-reference.md
 
 Docs configuration is done using the [`fractal.docs.set()`](../api/endpoints/fractal-docs.html#set-path-value) method.
 
-To specify the directory that your [documentation pages](./documentation) will reside in, you can use the `path` setting:
+To specify the directory that your [documentation pages](./documentation/) will reside in, you can use the `path` setting:
 
 ```js
 fractal.docs.set('path', __dirname + '/src/docs');

--- a/docs/guide/web/default-theme.md
+++ b/docs/guide/web/default-theme.md
@@ -111,7 +111,7 @@ This option can also take an **array** of stylesheets URLs to use. If you do not
 In this case the default Mandelbrot stylesheet link will be output between the two other custom styleheets.
 
 ::: warning
-This option **is not used** for applying styles to your _components_ - for information on how to include component stylesheets see the docs on linking to [static assets](../web#static-assets).
+This option **is not used** for applying styles to your _components_ - for information on how to include component stylesheets see the docs on linking to [static assets](../web/#static-assets).
 :::
 
 ### scripts
@@ -140,7 +140,7 @@ This option can also take an **array** of JavaScript file URLs to use. If you do
 In this case the default Mandelbrot script tag link will be output between the two other custom script sources.
 
 ::: warning
-This option **is not used** for applying JavaScript to your _components_ - for information on how to include component JS files see the docs on linking to [static assets](../web#static-assets).
+This option **is not used** for applying JavaScript to your _components_ - for information on how to include component JS files see the docs on linking to [static assets](../web/#static-assets).
 :::
 
 


### PR DESCRIPTION
On some pages were links that missed a `/` at the end of the url, which caused the search to fail on the linked-to pages. These I've added. Related issue: #16