### PR TITLE
docs: add collection’s root option

### DIFF
--- a/docs/guide/collections/configuration-reference.md
+++ b/docs/guide/collections/configuration-reference.md
@@ -44,6 +44,18 @@ The string that is used when a UI needs a title for the collection. Defaults to 
 title: 'My Favourite Website Layouts'
 ```
 
+#### root <Badge text="added in v1.5.0" type="tip"/> <Badge text="requires Mandelbrot v1.6+" type="warning"/>
+
+Pull the collection to the navigation top level, next to the defaults "Components" and "Documentation".
+
+```yaml
+root: true
+```
+
+::: warning
+`root` option is available only for component collections, it won’t work for documentation.
+:::
+
 ## Heritable properties
 
 The majority of properties set in a collection configuration file apply not to the collection itself, but instead act as defaults which cascade down to the items within it.


### PR DESCRIPTION
closes #75