### PR TITLE
Fix href in "edit this page" links

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -6,6 +6,7 @@ module.exports = {
     ['link', { rel: 'icon', href: '/favicon.png' }]
   ],
   themeConfig: {
+    docsBranch: 'main',
     docsDir: 'docs',
     lastUpdated: 'Last Updated', // string | boolean
     repo: 'frctl/fractal-docs',


### PR DESCRIPTION
Since the default branch of fractal-docs changed to `main`, the "edit page" links at the bottom of each page no longer work, because VuePress assuming the default branch to still be `master`. This PR adds the [VuePress `docsBranch` config value](https://vuepress.vuejs.org/theme/default-theme-config.html#git-repository-and-edit-links) to correct these links.